### PR TITLE
Wish new grad position is no longer available

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Here are some resources Coder Quad recommends to prepare for OA's and technical 
 |[Amazon](https://www.amazon.jobs/en/jobs/1558079/software-development-engineer-2022-us?cmpid=SPLICX0248M&utm_source=linkedin.com&utm_campaign=cxro&utm_medium=social_media&utm_content=job_posting&ss=paid) | US | New Grad SDE |
 |[Arrowstreet Capital](https://arrowstreetcapital.wd5.myworkdayjobs.com/en-US/Arrowstreet/details/XMLNAME-2022-Technology-Rotational-Development-Program_R523) | Boston | SWE Technology Rotational Development Program |
 |[Jane Street](https://www.janestreet.com/join-jane-street/position/5311286002/) | NYC | |
-[Wish](https://jobs.smartrecruiters.com/Wish/743999745330820)| SF | [Other positions available](https://www.wish.com/careers/jobs) |
 [Hudson River Trading](https://www.hudsonrivertrading.com/careers/job/?gh_jid=82675)| New York | Algo Developer, [SWE](https://www.hudsonrivertrading.com/careers/job/?gh_jid=86641) |
 |[Fidelity](https://jobs.fidelity.com/job-details/13162494/2021-2022-undergraduates-full-stack-engineer-merrimack-nh/)| Boston + others | Full-Stack Engineer |
 |[Stytch](https://jobs.ashbyhq.com/stytch/b4ee9734-3657-4393-8eca-269ae179d7eb) | SF | |


### PR DESCRIPTION
Wish 2022 new grad position is no longer available, they still have other roles though: https://www.wish.com/careers/jobs