### PR TITLE
Add Airtable

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Here are some resources Coder Quad recommends to prepare for OA's and technical 
 
 - [Competitive Programmer's Handbook](https://cses.fi/book/book.pdf)
 
-## The List
+
+## The List ([Airtable](https://airtable.com/shrS40XfZ5opJ3jLV)/[Submit](https://airtable.com/shrHLRT3pcaW8QBAv))
 
 | Name                                   | Location | Notes                                   |
 | -------------------------------------- | -------- | --------------------------------------- |


### PR DESCRIPTION
As per discussion in #143 , adding an Airtable link for the ability to sort/manage easily. I know from using the other repo from Pitt summer internship, the table gets very hard to read and go through as postings start coming in. 

Can add OP as owner of airtable if needed. 