### PR TITLE
Typo in Position Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Here are some resources Coder Quad recommends to prepare for OA's and technical 
 | [Capital One](https://www.capitalonecareers.com/job/mclean/technology-development-program-associate-2023/31238/31914108720) | US | Technology Development Program Associate |
 | [Virtu Financial](https://www.virtu.com/careers/) | New York, NY | Entry-Level Software Engineer |
 | [Citadel](https://www.citadel.com/careers/open-positions/positions-for-students/?keyword=Full%20Time) | US | Software Engineer |
-| [Philadelphia Phillies](https://boards.greenhouse.io/philadelphiaphilliesrddepartment/jobs/5203393003?gh_src=99fc01a23us) | Philadelphia, PA | Software Engineer Associate (Sprint/Summer 2023) |
+| [Philadelphia Phillies](https://boards.greenhouse.io/philadelphiaphilliesrddepartment/jobs/5203393003?gh_src=99fc01a23us) | Philadelphia, PA | Software Engineer Associate (Spring/Summer 2023) |
 | [Caterpillar](https://careers.caterpillar.com/en/jobs/job/r0000140356-2023-associate-software-engineer-cat-digital/?source=LinkedIn) | Champaign, IL | Associate Software Engineer (Cat Digital) |
 | [Procter & Gamble](https://www.pgcareers.com/job/cincinnati/software-data-engineer-2023-grads/936/32401863136) | Cincinnati, OH | Software/Data Engineer 2023 Grads |
 | [Optiver](https://www.optiver.com/working-at-optiver/career-opportunities/6254739002/?gh_src=9fb491cd2&gh_src=9fb491cd2) | Austin, TX | Graduate Software Engineer 2023 |


### PR DESCRIPTION
**Company:** Philadelphia Phillies 
**Position:** Software Engineer Associate (Spring/Summer 2023)

**Before:** Software Engineer Associate (Sprint/Summer 2023)
**After:** Software Engineer Associate (Spring/Summer 2023)

**Changes:** Changed 'Sprint' to 'Spring' to be consistent.
**Why:** User might get confused and have to double check the position name.
