### PR TITLE
Remove listing with duplicate id

### DIFF
--- a/.github/scripts/listings.json
+++ b/.github/scripts/listings.json
@@ -23778,24 +23778,6 @@
         "company_name": "Pylon",
         "id": "f2019b56-ba55-41fa-af52-f5aa7dad80a6",
         "title": "New Grad \u2013 Software Engineer",
-        "active": true,
-        "date_updated": 1756729929,
-        "date_posted": 1751902001,
-        "url": "https://jobs.ashbyhq.com/pylon-labs/ecf0d509-cfb9-43c6-b628-1e685d6f5f42/application",
-        "locations": [
-            "SF"
-        ],
-        "company_url": "https://simplify.jobs/c/Pylon",
-        "is_visible": false,
-        "sponsorship": "Other",
-        "degrees": []
-    },
-    {
-        "source": "Simplify",
-        "category": "Software",
-        "company_name": "Pylon",
-        "id": "f2019b56-ba55-41fa-af52-f5aa7dad80a6",
-        "title": "New Grad \u2013 Software Engineer",
         "active": false,
         "date_updated": 1752662543,
         "date_posted": 1751902001,


### PR DESCRIPTION
This removes a listing with a duplicate ID, which can be problematic for consuming projects (e.g. [goodfirstjob.com/new-grad-jobs](https://www.goodfirstjob.com/new-grad-jobs)). I opened https://github.com/SimplifyJobs/New-Grad-Positions/issues/1590 to remove the listing, but it didn't remove the listing. 🤷 Related #1589 

<img width="1708" height="1397" alt="Screenshot 2025-08-31 at 11 02 59 AM" src="https://github.com/user-attachments/assets/98bbb9dc-9217-4e12-9f54-c9fd1868603e" />
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed duplicate Pylon listing (id: f2019b56-ba55-41fa-af52-f5aa7dad80a6) from listings.json. Prevents ID collisions and duplicate entries for downstream consumers.

<!-- End of auto-generated description by cubic. -->

