### PR TITLE
Promise doesn't hire unless US individual so just added that

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Use this repo to share and keep track of entry-level software, tech, CS, PM, qua
 </tr>
 <tr>
 <td><strong><a href="https://simplify.jobs/c/Promise?utm_source=GHList&utm_medium=company">Promise</a></strong></td>
-<td>Software Engineer – New Grad - Forward Deployed AI</td>
+<td>Software Engineer – New Grad - Forward Deployed AI (🇺🇸) </td>
 <td>Oakland, CA</td>
 <td><div align="center"><a href="https://jobs.ashbyhq.com/Promise/f0a30718-faf0-4a34-8759-0d6335fa365a/application?utm_source=Simplify&ref=Simplify"><img src="https://i.imgur.com/fbjwDvo.png" width="52" alt="Apply"></a> <a href="https://simplify.jobs/p/f490ebdd-aaae-4bdf-af52-b3974fbf71b1?utm_source=GHList"><img src="https://i.imgur.com/aVnQdox.png" width="28" alt="Simplify"></a></div></td>
 <td>1d</td>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Marked the Promise “Software Engineer – New Grad - Forward Deployed AI” role as US-only by adding (🇺🇸) to the listing so candidates see the requirement up front. Also added a trailing newline to the README for consistent formatting.

<!-- End of auto-generated description by cubic. -->

