### PR TITLE
Add flag emoji to Ground Software Engineer position

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Use this repo to share and keep track of entry-level software, tech, CS, PM, qua
 <tbody>
 <tr>
 <td><strong><a href="https://simplify.jobs/c/Rocket-Lab-USA?utm_source=GHList&utm_medium=company">Rocket Lab USA</a></strong></td>
-<td>Ground Software Engineer 1/2</td>
+<td>Ground Software Engineer 1/2 🇺🇸 </td>
 <td>Littleton, CO</td>
 <td><div align="center"><a href="https://job-boards.greenhouse.io/rocketlab/jobs/7587006003?utm_source=Simplify&ref=Simplify"><img src="https://i.imgur.com/fbjwDvo.png" width="52" alt="Apply"></a> <a href="https://simplify.jobs/p/a6c0c87c-b335-4682-9080-d7f2b5e4ff0a?utm_source=GHList"><img src="https://i.imgur.com/aVnQdox.png" width="28" alt="Simplify"></a></div></td>
 <td>0d</td>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a U.S. flag emoji to the Rocket Lab “Ground Software Engineer 1/2” listing to make the country clear at a glance. Also adds the missing newline at the end of the README.

<sup>Written for commit 342f6d093d50ac8b4f88cf593f233008a543c862. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

