### PR TITLE
Add flag emoji to job title for Sphinx Defense

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Use this repo to share and keep track of entry-level software, tech, CS, PM, qua
 </tr>
 <tr>
 <td><strong><a href="https://simplify.jobs/c/Sphinx-Defense?utm_source=GHList&utm_medium=company">Sphinx Defense</a></strong></td>
-<td>Junior Associate Software Engineer</td>
+<td>Junior Associate Software Engineer 🇺🇸</td>
 <td>Colorado Springs, CO</td>
 <td><div align="center"><a href="https://job-boards.greenhouse.io/sphinxdefense/jobs/5119185008?utm_source=Simplify&ref=Simplify"><img src="https://i.imgur.com/fbjwDvo.png" width="52" alt="Apply"></a> <a href="https://simplify.jobs/p/5f9b0dbb-9932-4420-a9c4-582b63f396a1?utm_source=GHList"><img src="https://i.imgur.com/aVnQdox.png" width="28" alt="Simplify"></a></div></td>
 <td>0d</td>


### PR DESCRIPTION
Since the position requires the candidate to be a US citizen

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a US flag emoji to the Sphinx Defense job title in the README to clearly indicate the role requires US citizenship.

<sup>Written for commit 0b40e69aa489293de8d2eec03a0b48f48bd138d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

