### PR TITLE
Add flag emoji to Software Engineer 1 position at Captivation

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Use this repo to share and keep track of entry-level software, tech, CS, PM, qua
 <tbody>
 <tr>
 <td><strong><a href="https://simplify.jobs/c/Captivation?utm_source=GHList&utm_medium=company">Captivation</a></strong></td>
-<td>Software Engineer 1 - Linux/HPC/Bash/Python/Docker/Gitlab/CI/CD</td>
+<td>Software Engineer 1 🇺🇸 - Linux/HPC/Bash/Python/Docker/Gitlab/CI/CD</td>
 <td>Annapolis Junction, MD</td>
 <td><div align="center"><a href="https://job-boards.greenhouse.io/captivation/jobs/5230024008?utm_source=Simplify&ref=Simplify"><img src="https://i.imgur.com/fbjwDvo.png" width="52" alt="Apply"></a> <a href="https://simplify.jobs/p/5ae34582-a936-4638-a6b7-1452ac6dea22?utm_source=GHList"><img src="https://i.imgur.com/aVnQdox.png" width="28" alt="Simplify"></a></div></td>
 <td>0d</td>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a 🇺🇸 flag to the Captivation “Software Engineer 1” listing to indicate a US-based role in the positions table. Also restored the missing newline at the end of README for proper formatting.

<sup>Written for commit 8189b9c4308eaf35b4b8c9bdd33619df8756e60e. Summary will update on new commits. <a href="https://cubic.dev/pr/SimplifyJobs/New-Grad-Positions/pull/2898?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

